### PR TITLE
Assorted fixes

### DIFF
--- a/lib/WebDriver/Tiny.pm
+++ b/lib/WebDriver/Tiny.pm
@@ -224,6 +224,9 @@ sub find {
     my $must_be_visible
         = $method eq 'css selector' && $selector =~ s/:visible$//;
 
+    # FIXME
+    my $drv = ref $self eq 'WebDriver::Tiny::Elements' ? $self->[0] : $self;
+
     my @ids;
 
     for ( 0 .. ( $args{tries} // 5 ) ) {
@@ -234,10 +237,8 @@ sub find {
 
         @ids = map $_->{ELEMENT}, $reply->{value}->@*;
 
-        # FIXME This'll break when called on elems->find(), this always need
-        # to be $drv NOT $self.
         @ids = grep {
-            $self->_req( GET => "/element/$_/displayed" )->{value}
+            $drv->_req( GET => "/element/$_/displayed" )->{value}
         } @ids if $must_be_visible;
 
         last if @ids;
@@ -248,11 +249,8 @@ sub find {
     Carp::croak ref $self, qq/->find failed for $method = "$_[1]"/
         if !@ids && !exists $args{dies} && !$args{dies};
 
-    # FIXME
-    $self = $self->[0] if ref $self eq 'WebDriver::Tiny::Elements';
-
-    wantarray ? map { bless [ $self, $_ ], 'WebDriver::Tiny::Elements' } @ids
-              : bless [ $self, @ids ], 'WebDriver::Tiny::Elements';
+    wantarray ? map { bless [ $drv, $_ ], 'WebDriver::Tiny::Elements' } @ids
+              : bless [ $drv, @ids ], 'WebDriver::Tiny::Elements';
 }
 
 my $js = sub {

--- a/lib/WebDriver/Tiny.pm
+++ b/lib/WebDriver/Tiny.pm
@@ -384,6 +384,6 @@ sub _req {
     JSON::PP::decode_json $reply->{content};
 }
 
-sub DESTROY { $_[0]->_req( DELETE => '' ) if $_[0][3] }
+sub DESTROY { $_[0]->_req( DELETE => '' ) if $_[0][3] && $_[0][0] }
 
 1;

--- a/lib/WebDriver/Tiny.pm
+++ b/lib/WebDriver/Tiny.pm
@@ -229,7 +229,7 @@ sub find {
     for ( 0 .. ( $args{tries} // 5 ) ) {
         my $reply = $self->_req(
             POST => '/elements',
-            { using => $method, value => $selector },
+            { using => $method, value => "$selector" },
         );
 
         @ids = map $_->{ELEMENT}, $reply->{value}->@*;

--- a/lib/WebDriver/Tiny.pm
+++ b/lib/WebDriver/Tiny.pm
@@ -235,7 +235,16 @@ sub find {
             { using => $method, value => "$selector" },
         );
 
-        @ids = map $_->{ELEMENT}, $reply->{value}->@*;
+        my $type = ref $reply->{value};
+        if ($type eq 'ARRAY') {
+            @ids = map $_->{ELEMENT}, $reply->{value}->@*;
+        }
+        elsif ($type eq 'HASH') {
+            Carp::croak ref $self, qq/->find failed: $reply->{value}{message}/;
+        }
+        else {
+            Carp::croak ref $self, qq/->find failed: $reply->{value}/;
+        }
 
         @ids = grep {
             $drv->_req( GET => "/element/$_/displayed" )->{value}

--- a/t/t.pm
+++ b/t/t.pm
@@ -5,9 +5,6 @@ use warnings;
 
 require WebDriver::Tiny;
 
-# So we don't get a request at global destruction.
-undef *WebDriver::Tiny::DESTROY;
-
 sub import {
     # Turn on strict & warnings for the caller.
     strict->import;


### PR DESCRIPTION
* `$drv->find(4, method => 'link_text')` was failing for me under ChromeDriver; now fixed

* `$elements->find('a:visible')` is now implemented

* Some WebDriver server errors now yield exceptions that describe the problem (rather than accidentally triggering a "Not an ARRAY reference" error)

* When a WebDriver::Tiny instance is destroyed during global destruction, its destructor no longer tries to send a request using an HTTP::Tiny instance that's already been destroyed). This addresses issue #3. As a side benefit, the test suite no longer needs to delete the `DESTROY` method.

If you'd like me to rework this pull request in any way, please let me know — I'd be happy to oblige.

Thanks.