### PR TITLE
Use DesiredCapabilities rather than capabilties for Chrome

### DIFF
--- a/lib/WebDriver/Tiny.pod
+++ b/lib/WebDriver/Tiny.pod
@@ -61,7 +61,7 @@ targetting, below are some examples:
 =head2 ChromeDriver
 
  my $drv = WebDriver::Tiny->new(
-     capabilities => { chromeOptions => { binary => '/usr/bin/google-chrome' } },
+     DesiredCapabilities => { chromeOptions => { binary => '/usr/bin/google-chrome' } },
      port         => 9515,
  );
 


### PR DESCRIPTION
Attempting to use the latest version, v0.102 of Webdriver::Tiny gives the error

>invalid argument: unrecognized capability: chromeOption

The error comes from ChromeDriver. I am using v83. with Chromium v83.

```
[1592570630.554][INFO]: [3aeaec81370b4e7cb99f685bc4b748e4] COMMAND InitSession {
   "capabilities": {
      "alwaysMatch": {
         "chromeOptions": {
            "args": [ "disable-web-security", "ignore-certificate-errors" ],
            "binary": "C:\\Users\\Default\\Downloads\\chromium-83-0-4103\\chrome-win\\chrome.exe"
         }
      }
   }
}
[1592570630.568][INFO]: [3aeaec81370b4e7cb99f685bc4b748e4] RESPONSE InitSession ERROR invalid argument: unrecognized cap
ability: chromeOptions

```